### PR TITLE
user_idの追加

### DIFF
--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -61,7 +61,7 @@ class TopsController < ApplicationController
                                     :sending_cost, :user_id, :categories_id, :brand_id,
                                     :exhibition_status,:purchaser_id,
                                     images_attributes: [:image, :_destroy, :id]
-    )
+    ).merge(user_id: current_user.id)
   end
 
   def set_product

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,7 +2,7 @@ class Product < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :shipping
 
-#  belongs_to :user
+ belongs_to :user
 #  belongs_to :category
 #  belongs_to :brand
  has_one    :address

--- a/db/migrate/20200401093211_create_products.rb
+++ b/db/migrate/20200401093211_create_products.rb
@@ -8,7 +8,7 @@ class CreateProducts < ActiveRecord::Migration[5.2]
     t.integer     :sending,     null: false
     t.integer     :send_cost
     t.integer     :exhibition_status, null: false
-    t.bigint      :users_id,    foreign_key: true
+    t.bigint      :user_id,    foreign_key: true
     t.bigint      :categories_id,    foreign_key: true
     t.bigint      :brands_id,    foreign_key: true
     t.bigint      :shippings_id,  foreign_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,8 +44,7 @@ ActiveRecord::Schema.define(version: 2020_04_09_083031) do
   end
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "category_name"
-    t.string "category_detail"
+    t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "ancestry"
@@ -77,7 +76,7 @@ ActiveRecord::Schema.define(version: 2020_04_09_083031) do
     t.integer "sending", null: false
     t.integer "send_cost"
     t.integer "exhibition_status", null: false
-    t.bigint "users_id"
+    t.bigint "user_id"
     t.bigint "categories_id"
     t.bigint "brands_id"
     t.bigint "shippings_id"


### PR DESCRIPTION
出品時、productテーブルのuser_idカラムに、ログイン中のuser_idを追加できるようにした